### PR TITLE
Feature online mode

### DIFF
--- a/demoIsoObject.cpp
+++ b/demoIsoObject.cpp
@@ -23,7 +23,7 @@ static po::variables_map parseArguments(
 	desc.add_options()
 		("help,h", "print this message")
 		("listen-ip,i", po::value<std::string>()->default_value("0.0.0.0"), "The IP address that the isoObject will listen on.")
-        ("behaviour,b", po::value<std::string>()->default_value("follow-trajectory"), "The behaviour of the isoObject. Options are 'follow-trajectory' and 'circle'")
+        ("behaviour,b", po::value<std::string>()->default_value("follow-trajectory"), "The behaviour of the isoObject. Options are 'follow-trajectory', 'dynamic', and 'circle'")
 	;
 	po::store(po::parse_command_line(argc, argv, desc), ret);
 	po::notify(ret);
@@ -249,6 +249,12 @@ void runFollowTrajectory(myObject& obj) {
     }
 }
 
+
+void runDynamic(myObject& obj) {
+    std::cerr << "YOU HAVE STARTED THE DYNAMIC MODE!!" << std::endl;
+    std::cerr << "Test mode: " << obj.getObjectSettings().testMode << std::endl;
+}
+
 /**
  * @brief ISO-object that moves in a circle when connected.
  * 
@@ -294,6 +300,9 @@ int main(int argc, char** argv ) {
     std::string behaviour = args["behaviour"].as<std::string>();
     if (behaviour == "follow-trajectory") {
         runFollowTrajectory(obj);
+    }
+    else if (behaviour == "dynamic") {
+        runDynamic(obj);
     }
     else if (behaviour == "circle") {
         runCircle(obj);

--- a/demoIsoObject.cpp
+++ b/demoIsoObject.cpp
@@ -147,6 +147,14 @@ public:
         if (this->getObjectSettings().testMode == TEST_MODE_ONLINE){
             std::cout << "Test mode is online planned, appending new trajectory to existing" << std::endl;
             this->trajectory.insert(this->trajectory.end(), newTraj.begin(), newTraj.end());
+
+            // We might receive trajectories that overlap, we remove the duplicate points by checking the time
+            std::sort(this->trajectory.begin(), this->trajectory.end(), [](const TrajectoryWaypointType& t1, const TrajectoryWaypointType& t2) {
+                return t1.relativeTime.tv_sec * 1000000 + t1.relativeTime.tv_usec < t2.relativeTime.tv_sec * 1000000 + t2.relativeTime.tv_usec;
+            });
+            this->trajectory.erase(std::unique(this->trajectory.begin(), this->trajectory.end(), [](const TrajectoryWaypointType& t1, const TrajectoryWaypointType& t2) {
+                return t1.relativeTime.tv_sec * 1000000 + t1.relativeTime.tv_usec == t2.relativeTime.tv_sec * 1000000 + t2.relativeTime.tv_usec;
+            }), this->trajectory.end());
         } else {
             std::cout << "Test mode is preplanned, replacing existing trajectory" << std::endl;
             this->trajectory = newTraj;
@@ -223,7 +231,6 @@ void runFollowTrajectory(myObject& obj) {
             endZ = traj.back().pos.zCoord_m;
             startYaw = traj[0].pos.heading_rad;
             endYaw = traj.back().pos.heading_rad;
-
             obj.setMonr(endX, endY, endZ, endYaw, 0.0, 0.0);
             finishedRunning = false;
         }
@@ -250,9 +257,69 @@ void runFollowTrajectory(myObject& obj) {
 }
 
 
+/**
+ * @brief ISO-object that can be used with dynamic trajectories. The ISO-object works in the same way as runFollowTrajectory, but it will get
+ * a new trajectory at runtime, instead of the full trajectory when connecting.
+ * 
+ */
 void runDynamic(myObject& obj) {
-    std::cerr << "YOU HAVE STARTED THE DYNAMIC MODE!!" << std::endl;
-    std::cerr << "Test mode: " << obj.getObjectSettings().testMode << std::endl;
+    std::vector<TrajectoryWaypointType> traj;
+    double startX;
+    double endX;
+    double startY;
+    double endY;
+    double startZ;
+    double endZ;
+    double startYaw;
+    double endYaw;
+
+    auto finishedRunning = false;
+    while(1) {
+        auto state = obj.getCurrentStateName();
+        if (state == "Disarmed") {
+            // sleep for a while to get all trajectory points
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            traj = obj.getTrajectory();
+            startX = traj[0].pos.xCoord_m;
+            endX = traj.back().pos.xCoord_m;
+            startY = traj[0].pos.yCoord_m;
+            endY = traj.back().pos.yCoord_m;
+            startZ = traj[0].pos.zCoord_m;
+            endZ = traj.back().pos.zCoord_m;
+            startYaw = traj[0].pos.heading_rad;
+            endYaw = traj.back().pos.heading_rad;
+            obj.setMonr(endX, endY, endZ, endYaw, 0.0, 0.0);
+            finishedRunning = false;
+        }
+        else if (state == "Armed") {
+            obj.setMonr(startX, startY, startZ, startYaw, 0.0, 0.0);
+        }
+        else if (finishedRunning) {
+            obj.setMonr(endX, endY, endZ, endYaw, 0.0, 0.0);
+        }
+        else if (state == "Running") {
+            int i = 0;
+            TrajectoryWaypointType currentTraj;
+            TrajectoryWaypointType nextTraj;
+            while (i < traj.size()) {
+                currentTraj = traj[i];
+                nextTraj = traj[i+1];
+                auto secondsDiff = nextTraj.relativeTime.tv_sec - currentTraj.relativeTime.tv_sec;
+                auto microsecondsDiff = nextTraj.relativeTime.tv_usec - currentTraj.relativeTime.tv_usec;
+                auto timeDiff = secondsDiff * 1000000 + microsecondsDiff;
+
+                obj.setMonr(currentTraj.pos.xCoord_m, currentTraj.pos.yCoord_m, currentTraj.pos.zCoord_m, currentTraj.pos.heading_rad, currentTraj.spd.lateral_m_s, currentTraj.spd.longitudinal_m_s);
+                std::this_thread::sleep_for(std::chrono::microseconds(timeDiff));
+                ++i;
+                traj = obj.trajectory;
+            }
+            endX = currentTraj.pos.xCoord_m;
+            endY = currentTraj.pos.yCoord_m;
+            endZ = currentTraj.pos.zCoord_m;
+            endYaw = currentTraj.pos.heading_rad;
+            finishedRunning = true;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Added support for dynamic trajectories, use `./ISO_objectDemo -b dynamic` to launch the ISO-object in dynamic mode. The changes include:
- Dynamic mode, should work in the same way as "follow mode", except that new trajectories are fetched at runtime.
- The ISO-object can handle overlapping trajectories, if ATOS (or any other source) sends dynamic trajectories that have an overlap (meaning that the same waypoint gets sent twice or more), the ISO-object filtrates this out by checking the timestamp of the waypoint.