### PR TITLE
Switch tcp acceptor to async

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/RI-SE/iso22133
 [submodule "sigslot"]
 	path = sigslot
-	url = git@github.com:palacaze/sigslot.git
+	url = https://github.com:palacaze/sigslot.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/RI-SE/iso22133
 [submodule "sigslot"]
 	path = sigslot
-	url = https://github.com:palacaze/sigslot.git
+	url = https://github.com/palacaze/sigslot.git

--- a/inc/iso22133object.hpp
+++ b/inc/iso22133object.hpp
@@ -183,7 +183,6 @@ private:
 	std::mutex recvMutex;
 	std::mutex heabMutex;
 	std::mutex netwrkDelayMutex;
-    std::mutex disconnectMutex;
 	std::string localIP;
 	std::thread tcpReceiveThread;
 	std::thread udpReceiveThread;

--- a/inc/iso22133object.hpp
+++ b/inc/iso22133object.hpp
@@ -54,6 +54,7 @@ public:
 	virtual ~TestObject();
 
 	void disconnect();
+	void shutdown();
 
 	void setPosition(const CartesianPosition& pos) { position = pos; }
 	void setSpeed(const SpeedType& spd) { speed = spd; }

--- a/inc/iso22133state.hpp
+++ b/inc/iso22133state.hpp
@@ -149,7 +149,6 @@ private:
 class Init : public State {
 public:
 	virtual ObjectStateID getStateID() const final override { return ISO_OBJECT_STATE_INIT; }
-	virtual void onExit(TestObject&) override;
 private:
 	void handleTRAJ(TestObject&, std::atomic<HeaderType>&) final override { unexpectedMessageWarning("TRAJ"); }
 	void handleOSEM(TestObject&, ObjectSettingsType&) final override { unexpectedMessageWarning("OSEM"); }

--- a/inc/tcpServer.hpp
+++ b/inc/tcpServer.hpp
@@ -25,6 +25,7 @@ class TcpServer {
 				socket.shutdown(boost::asio::socket_base::shutdown_both);
 				socket.close();
 			}
+			context.reset();
 		} catch (boost::system::system_error& e) {
 			std::cerr << "Error when closing socket: " << e.what() << std::endl;
 		}
@@ -35,7 +36,12 @@ class TcpServer {
 			if (error) {
 				// Accepting failed, handle the error
 				// Print the error message for example
-				throw boost::system::system_error(boost::asio::error::eof);
+				if (error == boost::asio::error::operation_aborted) {
+					std::cerr << "TCP Accept aborted" << std::endl;
+				} else {
+					std::cerr << "TCP Accept error: " << error.message() << std::endl;
+					throw boost::system::system_error(boost::asio::error::eof);
+				}
 			}
 		});
 		context.run_one();

--- a/inc/tcpServer.hpp
+++ b/inc/tcpServer.hpp
@@ -21,8 +21,10 @@ class TcpServer {
 	void disconnect() {
 		try {
 			acceptor.cancel();
-			socket.shutdown(boost::asio::socket_base::shutdown_both);
-			socket.close();
+			if (socket.is_open()){
+				socket.shutdown(boost::asio::socket_base::shutdown_both);
+				socket.close();
+			}
 		} catch (boost::system::system_error& e) {
 			std::cerr << "Error when closing socket: " << e.what() << std::endl;
 		}

--- a/inc/trajDecoder.hpp
+++ b/inc/trajDecoder.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 
 #include "iso22133.h"
+#include "traj.h"
 
 /**
  * @brief Class for decoding TRAJ messages. Stores TRAJ data and

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -151,9 +151,9 @@ void TestObject::sendMonrLoop() {
 			if (this->transmitterID != TRANSMITTER_ID_UNAVAILABLE_VALUE){
 				sendMONR();
 			}
-			auto t = std::chrono::steady_clock::now();
-			std::this_thread::sleep_until(t + monrPeriod);
 		}
+		auto t = std::chrono::steady_clock::now();
+		std::this_thread::sleep_until(t + monrPeriod);
 	}
 }
 
@@ -180,6 +180,8 @@ void TestObject::receiveUDP() {
 				}
 				data.erase(data.begin(), data.begin() + nBytesHandled);
 			} while (data.size() > 0);
+		} else {
+			std::this_thread::sleep_for(heartbeatTimeout);
 		}
 	}
 }

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -48,7 +48,7 @@ TestObject::TestObject(const std::string& listenIP)
 }
 
 TestObject::~TestObject() {
-	on = false;
+	shutdown();
 	try {
 		udpReceiveThread.join();
 		monrThread.join();

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -85,9 +85,6 @@ void TestObject::disconnect() {
 
 void TestObject::receiveTCP() {
 	std::stringstream ss;
-	ss << "Started TCP thread." << std::endl;
-	std::cout << ss.str();
-
 	while (this->on) {
 		ss.str(std::string());
 		ss << "Awaiting TCP connection from ATOS..." << std::endl;
@@ -127,9 +124,6 @@ void TestObject::receiveTCP() {
 			state->handleEvent(*this, ISO22133::Events::L);
 		}
 	}
-	ss.str(std::string());
-	ss << "Exiting TCP thread." << std::endl;
-	std::cout << ss.str();
 }
 
 void TestObject::sendMONR(bool debug) {
@@ -162,10 +156,6 @@ void TestObject::sendGREM(HeaderType msgHeader, GeneralResponseStatus responseCo
 }
 
 void TestObject::sendMonrLoop() {
-	std::stringstream ss;
-	ss << "Started MONR thread." << std::endl;
-	std::cout << ss.str();
-
 	while (this->on) {
 		if (ctrlChannel.isOpen()) {
 			// Only send monr if transmitterID has been set by an OSEM message
@@ -176,18 +166,10 @@ void TestObject::sendMonrLoop() {
 			std::this_thread::sleep_until(t + monrPeriod);
 		}
 	}
-
-	ss.str(std::string());
-	ss << "Exiting MONR thread." << std::endl;
-	std::cout << ss.str();
 }
 
 void TestObject::receiveUDP() {
 	std::stringstream ss;
-	ss << "Started UDP communication thread." << std::endl;
-	ss << "Awaiting UDP data from ATOS..." << std::endl;
-	std::cout << ss.str();
-
 	awaitingFirstHeab = true;
 
 	while (this->on) {
@@ -197,12 +179,6 @@ void TestObject::receiveUDP() {
 			// Connection lost
 			if (data.size() <= 0) {
 				continue;
-			}
-
-			if (awaitingFirstHeab) {
-				ss.str(std::string());
-				ss << "Received UDP data from ATOS" << std::endl;
-				std::cout << ss.str();
 			}
 
 			int nBytesHandled = 0;
@@ -217,9 +193,6 @@ void TestObject::receiveUDP() {
 			} while (data.size() > 0);
 		}
 	}
-	ss.str(std::string());
-	ss << "Exiting UDP communication thread." << std::endl;
-	std::cout << ss.str();
 }
 
 void TestObject::checkHeabTimeout() {
@@ -237,10 +210,6 @@ void TestObject::checkHeabTimeout() {
 }
 
 void TestObject::checkHeabLoop() {
-	std::stringstream ss;
-	ss << "Started HEAB timeout thread." << std::endl;
-	std::cout << ss.str();
-
 	using namespace std::chrono;
 	while (this->on) {
 		auto t = std::chrono::steady_clock::now();
@@ -248,9 +217,6 @@ void TestObject::checkHeabLoop() {
 		// Don't lock the mutex all the time
 		std::this_thread::sleep_until(t + expectedHeartbeatPeriod);
 	}
-	ss.str(std::string());
-	ss << "Exiting HEAB timeout thread." << std::endl;
-	std::cout << ss.str();
 }
 
 void TestObject::onHeabTimeout() {

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -151,11 +151,11 @@ void TestObject::sendGREM(HeaderType msgHeader, GeneralResponseStatus responseCo
 
 void TestObject::sendMonrLoop() {
 	while (this->on) {
-		if (ctrlChannel.isOpen()) {
-			// Only send monr if transmitterID has been set by an OSEM message
-			if (this->transmitterID != TRANSMITTER_ID_UNAVAILABLE_VALUE){
-				sendMONR();
-			}
+		// Only send monr connection has been established if transmitterID has been set by an OSEM message
+		if (ctrlChannel.isOpen() &&
+			!awaitingFirstHeab &&
+			this->transmitterID != TRANSMITTER_ID_UNAVAILABLE_VALUE) {
+			sendMONR();
 		}
 		auto t = std::chrono::steady_clock::now();
 		std::this_thread::sleep_until(t + monrPeriod);
@@ -164,8 +164,6 @@ void TestObject::sendMonrLoop() {
 
 void TestObject::receiveUDP() {
 	std::stringstream ss;
-	awaitingFirstHeab = true;
-
 	while (this->on) {
 		if (ctrlChannel.isOpen()) {
 			auto data = processChannel.receive();

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -60,6 +60,11 @@ TestObject::~TestObject() {
 	}
 };
 
+void TestObject::shutdown() {
+	disconnect();
+	this->on = false;
+}
+
 void TestObject::disconnect() {
 	try {
 		ctrlChannel.disconnect();  // Close TCP socket

--- a/src/iso22133object.cpp
+++ b/src/iso22133object.cpp
@@ -51,23 +51,12 @@ TestObject::~TestObject() {
 	on = false;
 	try {
 		udpReceiveThread.join();
-	} catch (std::system_error&) {
-	}
-	try {
 		monrThread.join();
-	} catch (std::system_error&) {
-	}
-	try {
 		tcpReceiveThread.join();
-	} catch (std::system_error&) {
-	}
-	try {
 		heabTimeoutThread.join();
-	} catch (std::system_error&) {
-	}
-	try {
 		delayedStrtThread.join();
-	} catch (std::system_error&) {
+	} catch (std::system_error& e) {
+		std::cerr << "Error joining threads in TestObject destructor: " << e.what() << std::endl;
 	}
 };
 

--- a/src/iso22133state.cpp
+++ b/src/iso22133state.cpp
@@ -212,10 +212,6 @@ void ISO22133::State::handleTRAJ(TestObject& obj, std::atomic<HeaderType>& msgHe
 	}
 }
 
-void ISO22133::Init::onExit(TestObject& obj) {
-	obj.startHandleUDP();
-}
-
 /**
  * @brief Sets TestObject ready to arm flag
  *

--- a/src/iso22133state.cpp
+++ b/src/iso22133state.cpp
@@ -124,7 +124,8 @@ void ISO22133::State::handleOSEM(TestObject& obj, ObjectSettingsType& osem) {
 
 	obj.heartbeatTimeout = 10*obj.expectedHeartbeatPeriod;
 	msg.str(std::string());
-	msg << "Set HEAB timeout to" << obj.heartbeatTimeout.count() << std::endl;
+	msg << "Set HEAB timeout to " << obj.heartbeatTimeout.count() << " ms. ("
+		<< 1000 / obj.heartbeatTimeout.count() << " Hz) " << std::endl;
 	std::cout << msg.str();
 
 	obj.monrPeriod = std::chrono::milliseconds(1000 / (uint)osem.rate.monr);

--- a/src/trajDecoder.cpp
+++ b/src/trajDecoder.cpp
@@ -31,13 +31,12 @@ ssize_t TrajDecoder::DecodeTRAJ(std::vector<char>& dataBuffer, bool debug) {
 
     // Decode TRAJ waypoints
     int tmpSize;
-    int tmpCounter = nPointsHandled;
     TrajectoryWaypointType waypoint;
 
     tmpSize = trajecoryHeader.nWaypoints - nPointsHandled;
     for(int i = 0; i < tmpSize; i++) {
         // Save the bytes remaining and return
-        if(copiedData.size() < sizeof(TrajectoryWaypointType)) { 
+        if(copiedData.size() < sizeof(TRAJPointType)) { 
             unhandledBytes.resize(copiedData.size());
             unhandledBytes = copiedData; 	
             break;


### PR DESCRIPTION
The old accept method made the tcp thread blocking until a connection was made.
This was not cleanly cancelable from outside the thread.
This commit adds the acceptor.cancel() method stopping all pending accepts, freeing the thread.