### PR TITLE
Fix/test building default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   BUILD_TESTING: ON 
+  WITH_SWIG: ON
+  SWIG_WITH_PYTHON: ON
 
 jobs:
   test:
@@ -33,7 +35,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTING=${{env.BUILD_TESTING}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTING=${{env.BUILD_TESTING}} -DWITH_SWIG=${{env.WITH_SWIG}} -DSWIG_WITH_PYTHON=${{env.SWIG_WITH_PYTHON}}
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,12 @@ set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
 
 # Build flags
 set(BUILDING_FOR_ANDROID OFF CACHE BOOL "Building for Android")
+set(BUILD_TESTING OFF CACHE BOOL "Enable testing")
 
 # Swig flags
 set(WITH_SWIG OFF CACHE BOOL "Enable swigging")
 set(SWIG_WITH_JAVA OFF CACHE BOOL "Swig to target-language java")
 set(SWIG_WITH_PYTHON OFF CACHE BOOL "Swig to target-language python")
-
-if (BUILD_TESTING)
-    set(WITH_SWIG ON)
-    set(SWIG_WITH_PYTHON ON)
-endif()
 
 if(SWIG_WITH_JAVA)
     set(SWIG_TARGET_LANG java)


### PR DESCRIPTION
When building isoObject with colcon build, BUILD_TESTING is "ON" by default which makes compiler look for SWIG (fails builds if SWIG isn't installed and you don't want to build it). 

Removed compulsory SWIG dependency when building tests and also added an "OFF" default to the BUILD_TESTING flag for non maintainers.