### PR TITLE
Added atomic include

### DIFF
--- a/inc/iso22133state.hpp
+++ b/inc/iso22133state.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <iostream>
 #include <functional>
+#include <atomic>
 extern "C"{
 #include "iso22133.h"
 #include "header.h"


### PR DESCRIPTION
There was a missing include that somehow resolved on its own when building isoObject but not when exporting. Added the include for atomic.